### PR TITLE
Update MD_MIDITrack.cpp

### DIFF
--- a/src/MD_MIDITrack.cpp
+++ b/src/MD_MIDITrack.cpp
@@ -218,7 +218,7 @@ void MD_MFTrack::parseEvent(MD_MIDIFile *mf)
       sev.data[index++] = eType;
       sev.size++;
     }
-    uint16_t minLen = min(sev.size, ARRAY_SIZE(sev.data));
+    uint16_t minLen = min((unsigned int)sev.size, ARRAY_SIZE(sev.data));
     // The length parameter includes the 0xF7 but not the start boundary.
     // However, it may be bigger than our buffer will allow us to store.
     for (uint16_t i=index; i<minLen; ++i)


### PR DESCRIPTION
Just proposing this change, i'm not sure that it won't negatively impact other library users.....

This fix is for the ESP32 to work with the library. The ESP32 developers thought it would be a good idea to eschew the use of the min() macro provided by the standardized Arduino API in favor of the template based version used in the STL. Unlike Arduino's min(), this version of min() does not accept comparisons between different types.