### PR TITLE
SdFat Syntax Fix on Examples

### DIFF
--- a/PULL_REQUEST.md
+++ b/PULL_REQUEST.md
@@ -7,23 +7,23 @@ Describe the big picture of your changes here to communicate why we should accep
 ## Types of changes
 What types of changes does your code introduce?
 Put an `x` in the boxes that apply
-[ ] Bugfix (non-breaking change which fixes an issue)
+[X] Bugfix (non-breaking change which fixes an issue)
 [ ] New feature (non-breaking change which adds functionality)
 [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 
 ## Your Environment
-**Library Version:** 
-**Arduino IDE version:** 
-**Hardware model/type:** 
-**OS and Version:** 
+**Library Version:** Latest (2.6)
+**Arduino IDE version:** 2.0.3  
+**Hardware model/type:** Arduino Uno
+**OS and Version:** Windows 10
 
 ## Checklist
 Put an `x` in the boxes that apply. You can also fill these out after creating the PR.
 This is a reminder of what we are expecting before merging your code.
-[ ] Code compiles correctly/with no errors
+[X] Code compiles correctly/with no errors
 [ ] I have added tests that prove my fix is effective or that my feature works
 [ ] I have added or extended necessary documentation (if appropriate)
 [ ] Any dependent changes have been merged and published in downstream modules
 
 ## Further comments
-If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
+I was getting a SDFAT not a name type when compiling some code I was working on.  This was completly rectified by changing it from SDFAT to SdFat.  

--- a/examples/MD_MIDIFile_Dump/MD_MIDIFile_Dump.ino
+++ b/examples/MD_MIDIFile_Dump/MD_MIDIFile_Dump.ino
@@ -22,7 +22,7 @@ const uint8_t SD_SELECT = SS;
 // states for the state machine
 enum fsm_state { STATE_BEGIN, STATE_PROMPT, STATE_READ_FNAME, STATE_LOAD, STATE_PROCESS, STATE_CLOSE };
 
-SDFAT SD;
+SdFat SD;
 MD_MIDIFile SMF;
 
 void setup(void)

--- a/examples/MD_MIDIFile_Loop/MD_MIDIFile_Loop.ino
+++ b/examples/MD_MIDIFile_Loop/MD_MIDIFile_Loop.ino
@@ -37,7 +37,7 @@ const uint8_t SD_SELECT = SS;
 // list will be opened (skips errors).
 const char *loopfile = "LOOPDEMO.MID";  // simple and short file
 
-SDFAT	SD;
+SdFat	SD;
 MD_MIDIFile SMF;
 
 void midiCallback(midi_event *pev)

--- a/examples/MD_MIDIFile_Play/MD_MIDIFile_Play.ino
+++ b/examples/MD_MIDIFile_Play/MD_MIDIFile_Play.ino
@@ -75,7 +75,7 @@ const char *tuneList[] =
 //#define MIDI_FILE  "CHATCHOO.MID"   // 17 tracks
 //#define MIDI_FILE  "STRIPPER.MID"   // 25 tracks
 
-SDFAT	SD;
+SdFat	SD;
 MD_MIDIFile SMF;
 
 void midiCallback(midi_event *pev)

--- a/examples/MD_MIDIFile_PlayIO/MD_MIDIFile_PlayIO.ino
+++ b/examples/MD_MIDIFile_PlayIO/MD_MIDIFile_PlayIO.ino
@@ -58,7 +58,7 @@ const char fileName[] = "LOOPDEMO.MID";
 const uint8_t ACTIVE = HIGH;
 const uint8_t SILENT = LOW;
 
-SDFAT	SD;
+SdFat	SD;
 MD_MIDIFile SMF;
 
 // Define the list of I/O pins used by the application to play notes.

--- a/examples/MD_MIDIFile_Play_LCD/MD_MIDIFile_Play_LCD.ino
+++ b/examples/MD_MIDIFile_Play_LCD/MD_MIDIFile_Play_LCD.ino
@@ -68,7 +68,7 @@ MD_UISwitch_Analog::uiAnalogKeys_t kt[] =
 
 // Library objects -------------
 LiquidCrystal LCD(LCD_RS, LCD_ENA, LCD_D4, LCD_D5, LCD_D6, LCD_D7);
-SDFAT SD;
+SdFat SD;
 MD_MIDIFile SMF;
 MD_UISwitch_Analog LCDKey(LCD_KEYS, kt, ARRAY_SIZE(kt));
 

--- a/examples/MD_MIDIFile_Player_CLI/MD_MIDIFile_Player_CLI.ino
+++ b/examples/MD_MIDIFile_Player_CLI/MD_MIDIFile_Player_CLI.ino
@@ -42,7 +42,7 @@ void(*hwReset) (void) = 0;            // declare reset function @ address 0
 
 // Global Data
 bool printMidiStream = false;   // flag to print the real time midi stream
-SDFAT SD;
+SdFat SD;
 MD_MIDIFile SMF;
 
 void midiCallback(midi_event *pev)

--- a/examples/MD_MIDIFile_Tempo/MD_MIDIFile_Tempo.ino
+++ b/examples/MD_MIDIFile_Tempo/MD_MIDIFile_Tempo.ino
@@ -71,7 +71,7 @@ MD_UISwitch_Analog::uiAnalogKeys_t kt[] =
 
 // Library objects -------------
 LiquidCrystal LCD(LCD_RS, LCD_ENA, LCD_D4, LCD_D5, LCD_D6, LCD_D7);
-SDFAT SD;
+SdFat SD;
 MD_MIDIFile SMF;
 MD_UISwitch_Analog LCDKey(LCD_KEYS, kt, ARRAY_SIZE(kt));
 


### PR DESCRIPTION
I was having a "SDFAT does not name a type, did you mean ..." error when I attempted to compile for an Arduino Uno on the latest Arduino IDE 
Changing the capitalization of the SdFat call seems to fix it. 