### PR TITLE
 Fixed issue #2 with the use of 'min' function.  

### DIFF
--- a/src/MD_MIDIFile.h
+++ b/src/MD_MIDIFile.h
@@ -452,7 +452,7 @@ http://www.stephenhobley.com/blog/2011/03/14/the-last-darned-midi-interface-ill-
 
 // ------------- Configuration Section - END
 
-#define ARRAY_SIZE(a) (sizeof(a)/sizeof((a)[0]))
+#define ARRAY_SIZE(a) (uint32_t)(sizeof(a)/sizeof((a)[0]))
 
 #if DUMP_DATA
 #define DUMPS(s)    Serial.print(F(s))                            ///< Print a string

--- a/src/MD_MIDITrack.cpp
+++ b/src/MD_MIDITrack.cpp
@@ -218,7 +218,7 @@ void MD_MFTrack::parseEvent(MD_MIDIFile *mf)
       sev.data[index++] = eType;
       sev.size++;
     }
-    uint16_t minLen = min((unsigned int)sev.size, ARRAY_SIZE(sev.data));
+    uint16_t minLen = min((uint32_t)sev.size, ARRAY_SIZE(sev.data));
     // The length parameter includes the 0xF7 but not the start boundary.
     // However, it may be bigger than our buffer will allow us to store.
     for (uint16_t i=index; i<minLen; ++i)
@@ -414,7 +414,7 @@ void MD_MFTrack::parseEvent(MD_MIDIFile *mf)
 
       default:
       {
-        uint8_t minLen = min(ARRAY_SIZE(mev.data), mLen);
+        uint8_t minLen = min(ARRAY_SIZE(mev.data), (uint32_t)mLen);
         
         for (uint8_t i = 0; i < minLen; ++i)
           mev.data[i] = mf->_fd.read(); // read next


### PR DESCRIPTION
 Fixed issue #2 with the use of 'min' function.  This makes sure that the types for both parameters match so that the ESP32 standard library function is used instead of the STL function.